### PR TITLE
add <defnix/simple.nix> (extracted from ipsec-wrapper)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ deployment specification library.
 
 Defnix uses [nix-exec][1]. Its `default.nix` requires you to pass in the
 `nix-exec` lib and returns a `nix-exec` IO value. See
-`<defnix/defnixos/nixos-wrappers/ipsec-wrapper.nix>` for an example of how you
+`<defnix/simple.nix>` for an example of how you
 can use `defnix` when not using `nix-exec` for evaluation.
 
 Organization

--- a/defnixos/nixos-wrappers/ipsec-wrapper.nix
+++ b/defnixos/nixos-wrappers/ipsec-wrapper.nix
@@ -1,21 +1,7 @@
 { config, lib, pkgs, ... }: let
   cfg = config.defnixos;
 
-  pkgs-native = import pkgs.path {};
-
-  nix-exec = (import (pkgs-native.fetchgit {
-    url = "git://github.com/NixOS/nixpkgs.git";
-
-    rev = "c8be814f254311ca454844bdd34fd7206e801399";
-
-    sha256 = "0db22de19145f6859b8e5b40e4904c81e5fe4b00a86fbe8db684e68c25d3c0dd";
-  }) {}).nix-exec;
-
-  nix-exec-lib = import (nix-exec + "/share/nix/lib.nix");
-
-  unsafe-perform-io = import (nix-exec + "/share/nix/unsafe-perform-io.nix");
-
-  defnix = unsafe-perform-io (import ../../. nix-exec-lib { config.target-system = pkgs.system; });
+  defnix = import ../../simple.nix { inherit pkgs; };
 
   inherit (lib) types mkOption mapAttrsToList;
 

--- a/eval-support/proxy-bash.sh
+++ b/eval-support/proxy-bash.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+[ -f "$NIX_STORE/unsafe-env" ] && source "$NIX_STORE/unsafe-env"
+exec bash "$@"

--- a/eval-support/unsafe.nix
+++ b/eval-support/unsafe.nix
@@ -1,0 +1,23 @@
+rec {
+  unsafeDerivation = args: derivation ({
+    PATH = builtins.getEnv "PATH";
+    system = builtins.currentSystem;
+    builder = ./proxy-bash.sh;
+    preferLocalBuild = true;
+    __noChroot = true;
+  } // args);
+
+  shell = name: command: unsafeDerivation {
+    inherit name;
+    args = ["-c" command];
+  };
+
+  # working git must be in $PATH.
+  # increase (change) `clock' to trigger updates
+  shallow-fetchgit =
+    {url, branch ? "master", clock ? 1}:
+      shell "${baseNameOf (toString url)}-${toString clock}" ''
+        git clone --depth 1 -b ${branch} --recursive ${url} $out
+        cd $out
+      '';
+}

--- a/simple.nix
+++ b/simple.nix
@@ -1,0 +1,27 @@
+{ unsafe ? (builtins.getEnv "DEFNIX_UNSAFE") != ""
+, system ? "x86_64-linux"
+, pkgs ? import <nixpkgs> { inherit system; }
+, ... }:
+
+let
+  inherit (import ./eval-support/unsafe.nix) shallow-fetchgit;
+
+  nix-exec = ((if unsafe
+      then import (shallow-fetchgit {
+          url = "https://github.com/zalora/nixpkgs.git";
+          branch = "defnix-nix-exec";
+          clock = 3;
+        })
+      else import ((import pkgs.path {}).fetchgit {
+          url = "git://github.com/NixOS/nixpkgs.git";
+          rev = "c8be814f254311ca454844bdd34fd7206e801399";
+          sha256 = "0db22de19145f6859b8e5b40e4904c81e5fe4b00a86fbe8db684e68c25d3c0dd";
+        })
+  ) {}).nix-exec;
+
+  nix-exec-lib = import (nix-exec + "/share/nix/lib.nix");
+
+  unsafe-perform-io = import (nix-exec + "/share/nix/unsafe-perform-io.nix");
+
+in
+unsafe-perform-io (import ./. nix-exec-lib { config.target-system = system; })


### PR DESCRIPTION
changes:
- add `unsafe` argument to use shallow-fetchgit for bootstrapping
- add shallow-fetchgit that does not clone the whole repo and other
 unsafe stuff